### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,11 +5,6 @@
 # IDE files
 .idea
 
-# Temporary files and directories
-tmp
-*.tmp
-*.temp
-
 # Python cache files
 __pycache__
 *.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Version control
+.git
+.gitignore
+
+# IDE files
+.idea
+
+# Temporary files and directories
+tmp
+*.tmp
+*.temp
+
+# Python cache files
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environment
+venv
+env
+
+# Log files
+*.log
+
+# Results and output directories
+results

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install llvmlite
-RUN pip install llvmlite==0.29.0
+RUN pip install --no-cache-dir llvmlite==0.29.0
 
 # Clone and install pyTetris
 RUN git clone https://github.com/hrpan/pyTetris.git && \
     cd pyTetris && \
-    pip install .
+    pip install --no-cache-dir  .
 
 # Copy application code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Start with NVIDIA PyTorch image
+FROM nvcr.io/nvidia/pytorch:20.01-py3
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies (same as in requirements.txt but without torch, pytetris, caffe2)
+RUN pip install --no-cache-dir --ignore-installed \
+    numpy==1.17.2 \
+    dash_html_components==1.0.1 \
+    matplotlib==3.1.1 \
+    dash==1.4.1 \
+    plotly==4.3.0 \
+    cppimport==18.11.8 \
+    tables==3.5.2 \
+    numba==0.45.1 \
+    tqdm==4.36.1 \
+    dash_core_components==1.3.1 \
+    yattag==1.12.2 \
+    Pillow==7.2.0
+
+# Install additional system dependencies
+RUN apt-get update && apt-get install -y \
+    libhdf5-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install llvmlite
+RUN pip install llvmlite==0.29.0
+
+# Clone and install pyTetris
+RUN git clone https://github.com/hrpan/pyTetris.git && \
+    cd pyTetris && \
+    pip install .
+
+# Copy application code
+COPY . .
+
+# Set the default command to run your application
+#CMD ["python", "play.py", "--agent_type", "ValueSimLP", "--online", "--ngames", "1000", "--mcts_sims", "100"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ COPY . .
 # Create data directory
 RUN mkdir -p ./data
 
+# Set the entrypoint to python
+ENTRYPOINT ["python"]
+
 # Set the default command to run your application
-ENTRYPOINT ["python", "play.py"]
-CMD ["--agent_type", "ValueSimLP", "--online", "--ngames", "1000", "--mcts_sims", "100"]
+CMD ["play.py", "--agent_type", "ValueSimLP", "--online", "--ngames", "1000", "--mcts_sims", "100"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,9 @@ RUN git clone https://github.com/hrpan/pyTetris.git && \
 # Copy application code
 COPY . .
 
+# Create data directory
+RUN mkdir -p ./data
+
 # Set the default command to run your application
-#CMD ["python", "play.py", "--agent_type", "ValueSimLP", "--online", "--ngames", "1000", "--mcts_sims", "100"]
+ENTRYPOINT ["python", "play.py"]
+CMD ["--agent_type", "ValueSimLP", "--online", "--ngames", "1000", "--mcts_sims", "100"]

--- a/README.md
+++ b/README.md
@@ -25,9 +25,16 @@ However, such handcrafted rewards can bias your agents toward the target you set
 
 ## Prerequisite
 
-See `requirements.txt`
+See `requirements.txt` to install this project from source.
 
 You'll also need the Tetris environment from [here](https://github.com/hrpan/pyTetris), and the Python/C++ binding library [pybind11](https://github.com/pybind/pybind11).
+
+Alternatively, you can use the Dockerfile provided in this repository.
+
+```text
+docker build -f Dockerfile -t tetris-mcts .
+docker run --gpus all tetris-mcts
+```
 
 ## Training your agent
 


### PR DESCRIPTION
This is a Dockerfile for the repository. I found it difficult to get this project to run on my machine because of all the old dependencies, this Dockerfile solves the issue and installs the project.

## Usage

```
docker build -f Dockerfile -t tetris-mcts .
docker run --gpus all tetris-mcts
```

I also pushed a ready-to-use image to docker hub which you can use without building the image yourself.

```
docker run --gpus all mw2000/tetris-mcts:latest
```

The entry point is the `play.py` script, and the default parameters from the README are used.

## Dependencies

The requirements are the same as specified in `requirements.txt`, excluding `torch` (already included in `nvcr.io/nvidia/pytorch:20.01-py3`), `pyTetris` (installed manually as specified in the [README](https://github.com/hrpan/pyTetris) of the repository) and `caffe2`. `caffe2` is not included in this Dockerfile because the version `0.8.1` is not available on pypi and would have to be installed manually. This dependency still has to be installed manually.